### PR TITLE
Fix numbers len bug in UnitsText

### DIFF
--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -1493,11 +1493,11 @@ export class Timeline extends TimelineEventsEmitter {
     }
 
     if (minutes) {
-      str += minutes + ':';
+      str += hours ? TimelineUtils.timePadZero(minutes) : minutes + ':';
     }
 
     if (!isNaN(seconds)) {
-      str += seconds;
+      str += minutes ? TimelineUtils.timePadZero(seconds) : seconds;
     }
 
     return sign + str;

--- a/src/utils/timelineUtils.ts
+++ b/src/utils/timelineUtils.ts
@@ -285,4 +285,17 @@ export class TimelineUtils {
     mergeOptionsDeep(toArg, newOptions);
     return toArg;
   }
+  /**
+   * Format numbers with len
+   */
+  static timePadZero(num: number, len = 2): string {
+    let str = String(num);
+    const threshold = Math.pow(10, len - 1);
+    if (num < threshold) {
+      while (String(threshold).length > str.length) {
+        str = `0${num}`;
+      }
+    }
+    return str;
+  }
 }


### PR DESCRIPTION
Fix bug with unit text

Current
<img width="490" alt="Screenshot 2023-10-10 at 18 29 11" src="https://github.com/ievgennaida/animation-timeline-control/assets/11223987/aadfa063-2168-4754-932e-db14da6de34d">

With fix:
<img width="312" alt="Screenshot 2023-10-10 at 18 27 54" src="https://github.com/ievgennaida/animation-timeline-control/assets/11223987/a85d4a11-2bfa-46cb-a54b-e9468aaf8d3d">
